### PR TITLE
Schedule nix.gc for 1 hour before system.autoUpgrade

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -31,14 +31,16 @@
 
   services.flatpak.enable = true;
 
-  system.autoUpgrade.enable = true;
-  system.autoUpgrade.operation = "boot";
-  system.autoUpgrade.dates = "Mon 04:40";
-  system.autoUpgrade.channel = "https://nixos.org/channels/nixos-24.05";
+  system.autoUpgrade = {
+    enable = true;
+    operation = "boot";
+    dates = "Mon 04:40";
+    channel = "https://nixos.org/channels/nixos-24.05";
+  };
 
   nix.gc = {
     automatic = true;
-    dates = "weekly";
+    dates = "Mon 3:40";
     options = "--delete-older-than 30d";
   };
 

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -30,19 +30,17 @@
   system.autoUpgrade.dates = "Mon 04:40";
   system.autoUpgrade.channel = "https://nixos.org/channels/nixos-24.05";
 
-  nix.gc = {
-    automatic = true;
-    dates = "weekly";
-    options = "--delete-older-than 14d";
+  system.autoUpgrade = {
+    enable = true;
+    operation = "boot";
+    dates = "Mon 04:40";
+    channel = "https://nixos.org/channels/nixos-24.05";
   };
 
-  systemd.timers."auto-update-config" = {
-  wantedBy = [ "timers.target" ];
-    timerConfig = {
-      OnBootSec = "1m";
-      OnCalendar = "daily";
-      Unit = "auto-update-config.service";
-    };
+  nix.gc = {
+    automatic = true;
+    dates = "Mon 3:40";
+    options = "--delete-older-than 14d";
   };
 
   systemd.services."auto-update-config" = {


### PR DESCRIPTION
Instead of nix.gc running at a random time possibly interrupting work, run it Mon 03:40.