### PR TITLE
simplify README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,33 +48,25 @@ The **nixbook lite** version:
 nmtui
 ```
 
-
-## Step 5:  Go to /etc and nix-shell git
+## Step 5:  Clone the nixbook repo 
 ```
-cd /etc/
-nix-shell -p git
+sudo nix-shell -p git --run "git clone https://github.com/mkellyxp/nixbook"
 ```
 
-
-## Step 6:  Clone the nixbook repo  (make sure you run as sudo and you're in /etc!)
+## Step 6:  Run the install script (run this with NO sudo)
 ```
-sudo git clone https://github.com/mkellyxp/nixbook
-```
-
-## Step 7:  Run the install script (run this with NO sudo)
-```
-cd nixbook
+cd /etc/nixbook
 ./install.sh
 ```
 
 *or for nixbook lite*
 ```
-cd nixbook
+cd /etc/nixbook
 ./install_lite.sh
 ```
 
 
-## Step 8:  Enjoy nixbook!
+## Step 7:  Enjoy nixbook!
 
 You can always manually run updates by running **Update and Reboot** in the menu.
 


### PR DESCRIPTION
Small change to the readme.
At first, I just removed the notion of having to move to `/etc/` first just to git clone the repo. 
But then I realized, that you need to cd in to `/etc/nixbook` anyways, so I made a few more changes to it.