### PR TITLE
Improve responsiveness to user while upgrade service is running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ The goal is to create a "chromebook like" unbreakable computer to give to basic 
 
 ---
 Full video walk through of converting from Windows to Nixbook is now live here:
-
-<https://www.youtube.com/watch?v=uA-TjNQVR-M>
+<https://youtu.be/izvVjfqd5j8?si=ZJAdBZRsQO38YIy5>
 ---
 
 The default **nixbook** version:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The goal is to create a "chromebook like" unbreakable computer to give to basic 
 
 ---
 Full video walk through of converting from Windows to Nixbook is now live here:
+
 <https://youtu.be/izvVjfqd5j8?si=ZJAdBZRsQO38YIy5>
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The goal is to create a "chromebook like" unbreakable computer to give to basic 
 
 ---
 Full video walk through of converting from Windows to Nixbook is now live here:
+
 <https://www.youtube.com/watch?v=uA-TjNQVR-M>
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 The goal is to create a "chromebook like" unbreakable computer to give to basic users who know nothing about Linux and won't need to ever worry about updates / upgrades.
 
 ---
+Full video walk through of converting from Windows to Nixbook is now live here:
+<https://www.youtube.com/watch?v=uA-TjNQVR-M>
+---
 
 The default **nixbook** version:
 - ***32 gigs of storage and 4 gigs of ram recommended***

--- a/base.nix
+++ b/base.nix
@@ -103,13 +103,16 @@ in
       ${updateGitScript}
 
       # Flatpak Updates
-      ${pkgs.coreutils-full}/bin/nice -n 19 ${pkgs.util-linux}/bin/ionice -c 3 ${pkgs.flatpak}/bin/flatpak update --noninteractive --assumeyes
+      ${pkgs.flatpak}/bin/flatpak update --noninteractive --assumeyes
     '';
     serviceConfig = {
       Type = "oneshot";
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
+      CPUWeight = "20";
+      CPUQuota = "25%";
+      IOWeight = "20";
     };
 
     after = [ "network-online.target" "graphical.target" ];
@@ -136,7 +139,7 @@ in
 
       ${notifyUsersScript} "Starting System Updates" "System updates are installing in the background.  You can continue to use your computer while these are running."
             
-      ${pkgs.coreutils-full}/bin/nice -n 19 ${pkgs.util-linux}/bin/ionice -c 3 ${pkgs.nixos-rebuild}/bin/nixos-rebuild boot --upgrade
+      ${pkgs.nixos-rebuild}/bin/nixos-rebuild boot --upgrade
 
       # Fix for zoom flatpak
       ${pkgs.flatpak}/bin/flatpak override --env=ZYPAK_ZYGOTE_STRATEGY_SPAWN=0 us.zoom.Zoom
@@ -148,6 +151,9 @@ in
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
+      CPUWeight = "20";
+      CPUQuota = "25%";
+      IOWeight = "20";
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base.nix
+++ b/base.nix
@@ -111,7 +111,6 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "20";
-#      CPUQuota = "25%";
       IOWeight = "20";
     };
 
@@ -152,7 +151,6 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "20";
-#      CPUQuota = "25%";
       IOWeight = "20";
     };
 

--- a/base.nix
+++ b/base.nix
@@ -111,7 +111,7 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "20";
-      CPUQuota = "25%";
+#      CPUQuota = "25%";
       IOWeight = "20";
     };
 
@@ -152,7 +152,7 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "20";
-      CPUQuota = "25%";
+#      CPUQuota = "25%";
       IOWeight = "20";
     };
 

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -99,6 +99,9 @@ in
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
+      CPUWeight=20
+      CPUQuota=85%
+      IOWeight=20
     };
 
     after = [ "network-online.target" "graphical.target" ];
@@ -125,7 +128,7 @@ in
 
       ${notifyUsersScript} "Starting System Updates" "System updates are installing in the background.  You can continue to use your computer while these are running."
             
-      ${pkgs.coreutils-full}/bin/nice -n 19 ${pkgs.util-linux}/bin/ionice -c 3 ${pkgs.nixos-rebuild}/bin/nixos-rebuild boot --upgrade
+      ${pkgs.nixos-rebuild}/bin/nixos-rebuild boot --upgrade
 
       ${notifyUsersScript} "System Updates Complete" "Updates are complete!  Simply reboot the computer whenever is convenient to apply updates."
     '';
@@ -134,6 +137,9 @@ in
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
+      CPUWeight=20
+      CPUQuota=85%
+      IOWeight=20
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -40,7 +40,7 @@ let
 in
 {
   zramSwap.enable = true;
-  zramSwap.memoryPercent = 95;
+  zramSwap.memoryPercent = 100;
   systemd.extraConfig = ''
     DefaultTimeoutStopSec=10s
   '';

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -40,7 +40,7 @@ let
 in
 {
   zramSwap.enable = true;
-  zramSwap.memoryPercent = 100;
+  zramSwap.memoryPercent = 95;
   systemd.extraConfig = ''
     DefaultTimeoutStopSec=10s
   '';
@@ -103,6 +103,7 @@ in
       CPUWeight = "20";
       CPUQuota = "25%";
       IOWeight = "20";
+      MemoryHigh = "500M";
     };
 
     after = [ "network-online.target" "graphical.target" ];
@@ -141,6 +142,7 @@ in
       CPUWeight = "20";
       CPUQuota = "25%";
       IOWeight = "20";
+      MemoryHigh = "500M";
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -99,9 +99,9 @@ in
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
-      CPUWeight=20
-      CPUQuota=85%
-      IOWeight=20
+      CPUWeight = "20";
+      CPUQuota = "85%";
+      IOWeight = "20";
     };
 
     after = [ "network-online.target" "graphical.target" ];
@@ -137,9 +137,9 @@ in
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
-      CPUWeight=20
-      CPUQuota=85%
-      IOWeight=20
+      CPUWeight = "20";
+      CPUQuota = "85%";
+      IOWeight = "20";
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -102,7 +102,7 @@ in
       CPUWeight = "1";
       CPUQuota = "85%";
       IOWeight = "1";
-      TasksMax = "1";
+      TasksMax = "2";
       MemoryHigh = "100M";
     };
 
@@ -142,7 +142,7 @@ in
       CPUWeight = "1";
       CPUQuota = "85%";
       IOWeight = "1";
-      TasksMax = "1";
+      TasksMax = "2";
       MemoryHigh = "100M";
     };
 

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -101,7 +101,7 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "20";
-      CPUQuota = "25%";
+#      CPUQuota = "25%";
       IOWeight = "20";
       MemoryHigh = "500M";
     };
@@ -140,7 +140,7 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "20";
-      CPUQuota = "25%";
+#      CPUQuota = "25%";
       IOWeight = "20";
       MemoryHigh = "500M";
     };

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -99,9 +99,9 @@ in
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
-      CPUWeight = "1";
+      CPUWeight = "20";
       CPUQuota = "25%";
-      IOWeight = "1";
+      IOWeight = "20";
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -102,7 +102,6 @@ in
       CPUWeight = "1";
       CPUQuota = "85%";
       IOWeight = "1";
-      TasksMax = "2";
       MemoryHigh = "100M";
     };
 
@@ -142,7 +141,6 @@ in
       CPUWeight = "1";
       CPUQuota = "85%";
       IOWeight = "1";
-      TasksMax = "2";
       MemoryHigh = "100M";
     };
 

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -100,9 +100,8 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "1";
-      CPUQuota = "85%";
+      CPUQuota = "25%";
       IOWeight = "1";
-      MemoryHigh = "100M";
     };
 
     after = [ "network-online.target" "graphical.target" ];
@@ -139,9 +138,8 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "1";
-      CPUQuota = "85%";
+      CPUQuota = "25%";
       IOWeight = "1";
-      MemoryHigh = "100M";
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -40,6 +40,7 @@ let
 in
 {
   zramSwap.enable = true;
+  zramSwap.memoryPercent = 100;
   systemd.extraConfig = ''
     DefaultTimeoutStopSec=10s
   '';
@@ -102,7 +103,6 @@ in
       CPUWeight = "20";
       CPUQuota = "25%";
       IOWeight = "20";
-      MemorySwapMax = "0";
     };
 
     after = [ "network-online.target" "graphical.target" ];
@@ -141,7 +141,6 @@ in
       CPUWeight = "20";
       CPUQuota = "25%";
       IOWeight = "20";
-      MemorySwapMax = "0";
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -102,6 +102,7 @@ in
       CPUWeight = "20";
       CPUQuota = "25%";
       IOWeight = "20";
+      MemorySwapMax = "0";
     };
 
     after = [ "network-online.target" "graphical.target" ];
@@ -140,6 +141,7 @@ in
       CPUWeight = "20";
       CPUQuota = "25%";
       IOWeight = "20";
+      MemorySwapMax = "0";
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -137,9 +137,9 @@ in
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
-      CPUWeight = "1";
+      CPUWeight = "20";
       CPUQuota = "25%";
-      IOWeight = "1";
+      IOWeight = "20";
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -99,9 +99,11 @@ in
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
-      CPUWeight = "20";
+      CPUWeight = "1";
       CPUQuota = "85%";
-      IOWeight = "20";
+      IOWeight = "1";
+      TasksMax = "1";
+      MemoryHigh = "100M";
     };
 
     after = [ "network-online.target" "graphical.target" ];
@@ -137,9 +139,11 @@ in
       User = "root";
       Restart = "on-failure";
       RestartSec = "30s";
-      CPUWeight = "20";
+      CPUWeight = "1";
       CPUQuota = "85%";
-      IOWeight = "20";
+      IOWeight = "1";
+      TasksMax = "1";
+      MemoryHigh = "100M";
     };
 
     after = [ "network-online.target" "graphical.target" ];

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -101,7 +101,6 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "20";
-#      CPUQuota = "25%";
       IOWeight = "20";
       MemoryHigh = "500M";
     };
@@ -140,7 +139,6 @@ in
       Restart = "on-failure";
       RestartSec = "30s";
       CPUWeight = "20";
-#      CPUQuota = "25%";
       IOWeight = "20";
       MemoryHigh = "500M";
     };


### PR DESCRIPTION
With these settings I was about watch a YouTube video in FireFox without sync problems or noticeable dropped frames while the system was upgrading on an old chromebook with 2GB of RAM.  I came to these settings with lots of trial and error on two old laptops. This is how I think it's working.

---

Replace nice with systemd CPUWeight. Replace ionice with systemd IOWeight. This defiantly makes the code look cleaner.  I've seen a few suggestions around the internet that this is now the preferred method. It seems to increase responsiveness a small amount.

---

The bigger change is zramSwap.memoryPercent = 100; in NixOS Lite. This increases the amount of RAM that can be compressed with zramSwap from 10%-15% to 20%-30% when under memory pressure. This lets a system with 2GB of RAM use the equivalent of ~3.5GB uncompressed RAM. Processes run at about half speed while swapping memory in and out of zramSwap.  This is a good trade-off for the Lite version. I'm not sure it makes sense for the Base version.

MemoryHigh = "500M"; is round-about way keeping whatever the user is doing from swapping to zram causing unresponsiveness for a few seconds.  The systemd service will swap if it is using more than 500Mb of RAM. Since it normally uses a little over 1000Mb, it swap thrashes increasing the time and amount of CPU and time to complete the process. So the background upgrade process swap thrashes more and the foreground process (FireFox with one tab at least) does little to no swapping.