### PR TITLE
Recreate guides in AsciiDoc?

### DIFF
--- a/guides/default-user.adoc
+++ b/guides/default-user.adoc
@@ -1,0 +1,1 @@
+**By default all computers have both username and password set to "user".** You can change this in settings later.

--- a/guides/end.adoc
+++ b/guides/end.adoc
@@ -1,0 +1,5 @@
+**That's it! Reboot about once a month and your computer should run perfectly for years to come.**
+
+If you have any questions, comments, or issues, check out the project’s page at:
+
+https://github.com/mkellyxp/nixbook

--- a/guides/getting-started-lite.adoc
+++ b/guides/getting-started-lite.adoc
@@ -1,0 +1,38 @@
+:leveloffset: +1
+:nixbook_name: Nixbook Lite
+
+include::intro.adoc[]
+
+__However, this lite version of nixbook is only loaded with basic apps and the Firefox web browser to keep things as light as possible.__
+
+include::default-user.adoc[]
+
+include::updates.adoc[]
+
+= Here is how to use the basics of your new computer
+
+On the bottom right, you'll see the time, battery and where you will connect to the Internet.
+
+Pressing the windows button, or clicking the Start logo in the bottom left, will open up your "start menu" where you can find all your programs, install new ones, change settings, shutdown and restart.
+
+To add new software (apps), click on the icon with the blue circle with the white dots.
+From there you can search for and install almost anything you'll need. And these are all completely free to install and use.
+(if you don’t see your apps after you install, just reboot and they should be in your menu)
+
+Clicking in the gray icon with the switches will get you into settings. You can customize your
+system exactly how you want. To change the default user and/or password, click on Users and
+Groups.
+
+Also in settings, if the fonts are too small (or big), click on Font Selection and change the text scaling.
+
+== What about Microsoft office?
+
+If you need to use the official MS Office for some reason. Simply use office 365 in your chrome browser.
+
+== What about games?
+
+Nixbook Lite is usually installed on lower spec computers that aren’t very powerful nor have much hard drive space. Therefore, these are just not set up for gaming. Any game that runs in your browser should work. Or cloud gaming services like Xbox cloud.
+
+https://www.xbox.com/en-US/cloud-gaming
+
+include::end.adoc[]

--- a/guides/getting-started.adoc
+++ b/guides/getting-started.adoc
@@ -1,0 +1,48 @@
+:leveloffset: +1
+
+:nixbook_name: Nixbook
+
+include::intro.adoc[]
+
+**However, you cannot install applications in the same way you can on Windows.**
+
+Nixbooks come pre-loaded with Google Chrome, Zoom, Libreoffice and a handful of other basic apps.
+This is all 99% of users need.
+And it also comes with a software store that is loaded with great free software.
+
+include::default-user.adoc[]
+
+include::updates.adoc[]
+
+= Here is how to use the basics of your new computer
+
+On the bottom right, you'll see the time, battery and where you will connect to the Internet.
+
+Pressing the windows button, or clicking the Start logo in the bottom left, will open up your "start menu" where you can find all your programs, install new ones, change settings, shutdown and restart.
+
+To add new software (apps), click on the icon with the blue circle with the white dots.
+From there you can search for and install almost anything you'll need. And these are all completely free to install and use.
+(if you don’t see your apps after you install, just reboot and they should be in your menu)
+
+Clicking in the gray icon with the switches will get you into settings. You can customize your system exactly how you want.
+To change the default user and/or password, click on Users and Groups.
+
+Also in settings, if the fonts are too small (or big), click on Font Selection and change the text scaling.
+
+== What about Microsoft office?
+
+Your computer is already loaded with Libreoffice, which is a free alternative to MS Office and fully compatible.
+However, if you need to use the official MS Office for some reason. Simply use office 365 in your chrome browser.
+
+== What about games?
+
+Your computer might already have some games installed, but you can also search the software center for more.
+Also in the software center, you can install Steam, and install pretty much any game you like (if your computer can run it)
+
+Once you are logged into Steam, click Steam / Settings, and click on Compatibility. "Toggle Enable Steam Play for all over titles".
+
+== What about other programs?
+
+If you do have a windows only program that you need to run, you can search for and install "Bottles" from the software center, which should allow you to install your windows only program.
+
+include::end.adoc[]

--- a/guides/intro.adoc
+++ b/guides/intro.adoc
@@ -1,0 +1,2 @@
+Welcome to your new {nixbook_name} Computer! These computers are loaded with an operating system that is lightweight, secure, self updating and forever free!
+While these computers are not running Windows, they look and operate the same way.

--- a/guides/updates.adoc
+++ b/guides/updates.adoc
@@ -1,0 +1,1 @@
+**Updates are automatic.** You simply have to reboot your computer once a month to make sure you're running the newest stuff.


### PR DESCRIPTION
I've migrated my sons' laptops from my custom NixOS configuration to NixBooks this week, and they work great.

One wanted Steam to play games and the other wanted something else from Flathub - both worked brilliantly along with LibreOffice and what they had before.

I'd like to contribute to the guides, but can only see the PDF versions in the repository.

To make them easier to contribute to, I've created some initial versions using AsciiDoc (the format I've been using recently for writing books) to see if this is something worth contributing back to the project?

Then, PRs can be made to the .adoc files if anyone wants to contribute.

If this is of interest, I'm happy to add the images and whatever else is needed, along with supporting documentation of how to build them using `asciidoctor`.