### PR TITLE
feat: respect users locale settings for home folders

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -98,15 +98,8 @@ in
     DefaultTimeoutStopSec=10s
   '';
 
-  # Enable the X11 windowing system.
-  services.xserver.enable = true;
-  nixpkgs.config.allowUnfree = true;
+  # Enable Bluetooth
   hardware.bluetooth.enable = true;
-
-  # Enable the Cinnamon Desktop Environment.
-  services.xserver.displayManager.lightdm.enable = true;
-  services.xserver.desktopManager.cinnamon.enable = true;
-  xdg.portal.enable = true;
 
   # Enable Printing
   services.printing.enable = true;
@@ -247,7 +240,6 @@ in
     builtins.elem (lib.getName pkg) [
     "broadcom-sta" # aka “wl”
   ];
-  
 }
 
 # Notes

--- a/base_lite.nix
+++ b/base_lite.nix
@@ -52,15 +52,8 @@ in
     DefaultTimeoutStopSec=10s
   '';
 
-  # Enable the X11 windowing system.
-  services.xserver.enable = true;
-  nixpkgs.config.allowUnfree = true;
+  # Enable Bluetooth
   hardware.bluetooth.enable = true;
-
-  # Enable the Cinnamon Desktop Environment.
-  services.xserver.displayManager.lightdm.enable = true;
-  services.xserver.desktopManager.cinnamon.enable = true;
-  xdg.portal.enable = true;
 
   # Enable Printing
   services.printing.enable = true;

--- a/config/applications/powerwash.desktop
+++ b/config/applications/powerwash.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Powerwash
 Comment=Run powerwash script
-Exec=gnome-terminal -- /etc/nixbook/powerwash.sh
+Exec=/etc/nixbook/powerwash.sh
 Icon=utilities-terminal
 Terminal=true
 Type=Application

--- a/config/applications/update.desktop
+++ b/config/applications/update.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Update and Reboot
 Comment=Run update and reboot script
-Exec=gnome-terminal -- /etc/nixbook/update.sh
+Exec=/etc/nixbook/update.sh
 Icon=utilities-terminal
 Terminal=true
 Type=Application

--- a/config/applications/update_shutdown.desktop
+++ b/config/applications/update_shutdown.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Update and Shut Down
 Comment=Run update and shut down script
-Exec=gnome-terminal -- /etc/nixbook/update_shutdown.sh
+Exec=/etc/nixbook/update_shutdown.sh
 Icon=utilities-terminal
 Terminal=true
 Type=Application

--- a/config/applications_lite/powerwash.desktop
+++ b/config/applications_lite/powerwash.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Powerwash
 Comment=Run powerwash script
-Exec=gnome-terminal -- /etc/nixbook/powerwash_lite.sh
+Exec=/etc/nixbook/powerwash_lite.sh
 Icon=utilities-terminal
 Terminal=true
 Type=Application

--- a/config/applications_lite/update.desktop
+++ b/config/applications_lite/update.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Update and Reboot
 Comment=Run update and reboot script
-Exec=gnome-terminal -- /etc/nixbook/update_lite.sh
+Exec=/etc/nixbook/update_lite.sh
 Icon=utilities-terminal
 Terminal=true
 Type=Application

--- a/config/applications_lite/update_shutdown.desktop
+++ b/config/applications_lite/update_shutdown.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Update and Shut Down
 Comment=Run update and shut down script
-Exec=gnome-terminal -- /etc/nixbook/update_shutdown_lite.sh
+Exec=/etc/nixbook/update_shutdown_lite.sh
 Icon=utilities-terminal
 Terminal=true
 Type=Application

--- a/install.sh
+++ b/install.sh
@@ -5,16 +5,23 @@ if [[ "$answer" =~ ^[Yy]$ ]]; then
   echo "Installing NixBook..."
 
   # Set up local files
-  rm -rf ~/
-  mkdir ~/Desktop
-  mkdir ~/Documents
-  mkdir ~/Downloads
-  mkdir ~/Pictures
+  source ~/.config/user-dirs.dirs
+  cp ~/.config/user-dirs.{dirs,locale} /tmp/
+  rm -rf ~/* && rm -rf ~/.*
+  mkdir $XDG_DESKTOP_DIR
+  mkdir $XDG_DOCUMENTS_DIR
+  mkdir $XDG_DOWNLOAD_DIR
+  mkdir $XDG_MUSIC_DIR
+  mkdir $XDG_PICTURES_DIR
+  mkdir $XDG_PUBLICSHARE_DIR
+  mkdir $XDG_TEMPLATES_DIR
+  mkdir $XDG_VIDEOS_DIR
   mkdir ~/.local
   mkdir ~/.local/share
-  cp -R /etc/nixbook/config/config ~/.config
-  cp /etc/nixbook/config/desktop/* ~/Desktop/
-  cp -R /etc/nixbook/config/applications ~/.local/share/applications
+  cp -R /etc/nixbook/config/config/* ~/.config
+  mv /tmp/user-dirs.{dirs,locale} ~/.config/
+  cp /etc/nixbook/config/desktop/* $XDG_DESKTOP_DIR/
+  cp -R /etc/nixbook/config/applications/* ~/.local/share/applications
 
   # The rest of the install should be hands off
   # Add Nixbook config and rebuild

--- a/install_lite.sh
+++ b/install_lite.sh
@@ -5,16 +5,23 @@ if [[ "$answer" =~ ^[Yy]$ ]]; then
   echo "Installing NixBook Lite..."
 
   # Set up local files
-  rm -rf ~/
-  mkdir ~/Desktop
-  mkdir ~/Documents
-  mkdir ~/Downloads
-  mkdir ~/Pictures
+  source ~/.config/user-dirs.dirs
+  cp ~/.config/user-dirs.{dirs,locale} /tmp/
+  rm -rf ~/* && rm -rf ~/.*
+  mkdir $XDG_DESKTOP_DIR
+  mkdir $XDG_DOCUMENTS_DIR
+  mkdir $XDG_DOWNLOAD_DIR
+  mkdir $XDG_MUSIC_DIR
+  mkdir $XDG_PICTURES_DIR
+  mkdir $XDG_PUBLICSHARE_DIR
+  mkdir $XDG_TEMPLATES_DIR
+  mkdir $XDG_VIDEOS_DIR
   mkdir ~/.local
   mkdir ~/.local/share
-  cp -R /etc/nixbook/config/config_lite ~/.config
-  cp /etc/nixbook/config/desktop_lite/* ~/Desktop/
-  cp -R /etc/nixbook/config/applications_lite ~/.local/share/applications
+  cp -R /etc/nixbook/config/config_lite/* ~/.config
+  mv /tmp/user-dirs.{dirs,locale} ~/.config/
+  cp /etc/nixbook/config/desktop_lite/* $XDG_DESKTOP_DIR/
+  cp -R /etc/nixbook/config/applications_lite/* ~/.local/share/applications
 
   # Add Nixbook config and rebuild
   sudo sed -i '/hardware-configuration\.nix/a\      /etc/nixbook/base_lite.nix' /etc/nixos/configuration.nix

--- a/powerwash.sh
+++ b/powerwash.sh
@@ -7,16 +7,23 @@ echo "Powerwashing NixBook..."
   sudo systemctl start auto-update-config.service;
   
   # Erase data and set up home directory again
-  rm -rf ~/
-  mkdir ~/Desktop
-  mkdir ~/Documents
-  mkdir ~/Downloads
-  mkdir ~/Pictures
+  source ~/.config/user-dirs.dirs
+  cp ~/.config/user-dirs.{dirs,locale} /tmp/
+  rm -rf ~/* && rm -rf ~/.*
+  mkdir $XDG_DESKTOP_DIR
+  mkdir $XDG_DOCUMENTS_DIR
+  mkdir $XDG_DOWNLOAD_DIR
+  mkdir $XDG_MUSIC_DIR
+  mkdir $XDG_PICTURES_DIR
+  mkdir $XDG_PUBLICSHARE_DIR
+  mkdir $XDG_TEMPLATES_DIR
+  mkdir $XDG_VIDEOS_DIR
   mkdir ~/.local
   mkdir ~/.local/share
-  cp -R /etc/nixbook/config/config ~/.config
-  cp /etc/nixbook/config/desktop/* ~/Desktop/
-  cp -R /etc/nixbook/config/applications ~/.local/share/applications
+  cp -R /etc/nixbook/config/config_lite/* ~/.config
+  mv /tmp/user-dirs.{dirs,locale} ~/.config/
+  cp /etc/nixbook/config/desktop_lite/* $XDG_DESKTOP_DIR/
+  cp -R /etc/nixbook/config/applications_lite/* ~/.local/share/applications
 
   sudo rm -r /var/lib/flatpak
 

--- a/powerwash_lite.sh
+++ b/powerwash_lite.sh
@@ -8,15 +8,22 @@ echo "Powerwashing NixBook Lite..."
   sudo systemctl start auto-update-config.service;
   
   # Erase data and set up home directory again
-  rm -rf ~/
-  mkdir ~/Desktop
-  mkdir ~/Documents
-  mkdir ~/Downloads
-  mkdir ~/Pictures
+  source ~/.config/user-dirs.dirs
+  cp ~/.config/user-dirs.{dirs,locale} /tmp/
+  rm -rf ~/* && rm -rf ~/.*
+  mkdir $XDG_DESKTOP_DIR
+  mkdir $XDG_DOCUMENTS_DIR
+  mkdir $XDG_DOWNLOAD_DIR
+  mkdir $XDG_MUSIC_DIR
+  mkdir $XDG_PICTURES_DIR
+  mkdir $XDG_PUBLICSHARE_DIR
+  mkdir $XDG_TEMPLATES_DIR
+  mkdir $XDG_VIDEOS_DIR
   mkdir ~/.local
   mkdir ~/.local/share
-  cp -R /etc/nixbook/config/config_lite ~/.config
-  cp /etc/nixbook/config/desktop_lite/* ~/Desktop/
+  cp -R /etc/nixbook/config/config_lite/* ~/.config
+  mv /tmp/user-dirs.{dirs,locale} ~/.config/
+  cp /etc/nixbook/config/desktop_lite/* $XDG_DESKTOP_DIR/
   cp -R /etc/nixbook/config/applications_lite ~/.local/share/applications
 
   # Clear space and rebuild


### PR DESCRIPTION
# Respect users selection from installer selected desktop

This PR should:
- keep the users locale for home folders as they selected it when installing.
- keep the users desktop environment as they choose it as all the config for that is already added to `/etc/nixos/configuration.nix`
- fixes `powerwash.desktop` and other scripts to be also shown in Gnome
- properly deletes all files in users home folder as the `rm -rf ~/` said it didn't have access to delete that folder (unless we set it to run with `sudo`)