### PR TITLE
Refactor config into multiple files

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -1,6 +1,11 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
-  nixChannel = "https://nixos.org/channels/nixos-25.05"; 
+  nixChannel = "https://nixos.org/channels/nixos-25.05";
 
   ## Notify Users Script
   notifyUsersScript = pkgs.writeScript "notify-users.sh" ''
@@ -35,7 +40,7 @@ let
   ## Update Git and Channel Script
   updateGitScript = pkgs.writeScript "update-git.sh" ''
     set -eu
-    
+
     # Update nixbook configs
     ${pkgs.git}/bin/git -C /etc/nixbook reset --hard
     ${pkgs.git}/bin/git -C /etc/nixbook clean -fd
@@ -93,46 +98,24 @@ let
   '';
 in
 {
-  zramSwap.enable = true;
+  imports = [
+    ./common.nix
+    ./installed.nix
+  ];
+
   systemd.extraConfig = ''
     DefaultTimeoutStopSec=10s
   '';
 
-  # Enable the X11 windowing system.
-  services.xserver.enable = true;
-  nixpkgs.config.allowUnfree = true;
-  hardware.bluetooth.enable = true;
-
-  # Enable the Cinnamon Desktop Environment.
-  services.xserver.displayManager.lightdm.enable = true;
-  services.xserver.desktopManager.cinnamon.enable = true;
   xdg.portal.enable = true;
-
-  # Enable Printing
-  services.printing.enable = true;
-  services.avahi = {
-    enable = true;
-    nssmdns4 = true;
-    openFirewall = true;
-  };
-
   environment.systemPackages = with pkgs; [
-    git
-    firefox
-    libnotify
-    gawk
     gnugrep
-    sudo
     dconf
     gnome-software
-    gnome-calculator
-    gnome-calendar
-    gnome-screenshot
     flatpak
     xdg-desktop-portal
     xdg-desktop-portal-gtk
     xdg-desktop-portal-gnome
-    system-config-printer
 
     (makeDesktopItem {
       name = "zoommtg-handler";
@@ -159,7 +142,10 @@ in
       RestartSec = "30s";
     };
 
-    after = [ "network-online.target" "flatpak-system-helper.service" ];
+    after = [
+      "network-online.target"
+      "flatpak-system-helper.service"
+    ];
     wants = [ "network-online.target" ];
     wantedBy = [ "multi-user.target" ];
   };
@@ -169,10 +155,10 @@ in
     dates = "Mon 3:40";
     options = "--delete-older-than 30d";
   };
-  
+
   # Auto update config, flatpak and channel
   systemd.timers."auto-update-config" = {
-  wantedBy = [ "timers.target" ];
+    wantedBy = [ "timers.target" ];
     timerConfig = {
       OnCalendar = "Tue..Sun";
       Persistent = true;
@@ -198,13 +184,16 @@ in
       IOWeight = "20";
     };
 
-    after = [ "network-online.target" "graphical.target" ];
+    after = [
+      "network-online.target"
+      "graphical.target"
+    ];
     wants = [ "network-online.target" ];
   };
 
   # Auto Upgrade NixOS
   systemd.timers."auto-upgrade" = {
-  wantedBy = [ "timers.target" ];
+    wantedBy = [ "timers.target" ];
     timerConfig = {
       OnCalendar = "Mon";
       Persistent = true;
@@ -238,16 +227,12 @@ in
       IOWeight = "20";
     };
 
-    after = [ "network-online.target" "graphical.target" ];
+    after = [
+      "network-online.target"
+      "graphical.target"
+    ];
     wants = [ "network-online.target" ];
   };
-
-  # Fix for the pesky "insecure" broadcom
-  nixpkgs.config.allowInsecurePredicate = pkg:
-    builtins.elem (lib.getName pkg) [
-    "broadcom-sta" # aka “wl”
-  ];
-  
 }
 
 # Notes

--- a/chromebook.nix
+++ b/chromebook.nix
@@ -1,0 +1,64 @@
+# Common config used by the installer, Nixbook, and Nixbook Lite
+{ pkgs, ... }:
+
+let
+  # Patched version of the alsa-ucm-conf package to also work on many Chromebooks
+  # Including this in all computers shouldn't break audio for non-Chromebooks
+  chromebook-ucm-conf =
+    with pkgs;
+    alsa-ucm-conf.overrideAttrs {
+      crosSrc = fetchFromGitHub {
+        owner = "WeirdTreeThing";
+        repo = "alsa-ucm-conf-cros";
+        rev = "a4e92135fd49e669b5ce096439289e05e25ae90c";
+        hash = "sha256-3TpzjmWuOn8+eIdj0BUQk2TeAU7BzPBi3FxAmZ3zkN8=";
+      };
+      postInstall = ''
+        cp -R $crosSrc/ucm2/* $out/share/alsa/ucm2
+        cp -R $crosSrc/overrides/* $out/share/alsa/ucm2/conf.d
+      '';
+    };
+in
+{
+  # Chromebook support
+  environment.systemPackages = with pkgs; [
+    # ectool is used for interacting with the ChromeOS Embedded Controller
+    # It is not needed for regular people to use Chromebooks, but it might be a helpful utility for troubleshooting
+    # The Framework ectool works well enough for Chromebooks
+    # Framework laptops use a similar, if not exact same ChromeOS Embedded Controller
+    # The ChromeOS ectool is not packaged in nixpkgs
+    fw-ectool
+    # For running the MrChromebox firmware utility script
+    dmidecode
+  ];
+  # For flashing firmware on Chromebooks
+  boot.kernelParams = [ "iomem=relaxed" ];
+  # For running the MrChromebox firmware utility script
+  programs.nix-ld = {
+    enable = true;
+    libraries = with pkgs; [
+      libusb1
+    ];
+  };
+
+  # For SOF audio on Chromebooks, adapted from https://github.com/WeirdTreeThing/chromebook-linux-audio
+  environment.sessionVariables.ALSA_CONFIG_UCM2 = "${chromebook-ucm-conf}/share/alsa/ucm2";
+  services.pipewire.wireplumber.configPackages = [
+    (pkgs.writeTextDir "share/wireplumber/wireplumber.conf.d/51-increase-headroom.conf" ''
+      monitor.alsa.rules = [
+        {
+          matches = [
+            {
+              node.name = "~alsa_output.*"
+            }
+          ]
+          actions = {
+            update-props = {
+              api.alsa.headroom = 2048
+            }
+          }
+        }
+      ]
+    '')
+  ];
+}

--- a/common.nix
+++ b/common.nix
@@ -1,0 +1,38 @@
+# Common config used by the installer, Nixbook, and Nixbook Lite
+{ pkgs, lib, ... }:
+
+{
+  imports = [
+    ./chromebook.nix
+  ];
+
+  zramSwap.enable = true;
+
+  # Enable the X11 windowing system.
+  services.xserver.enable = true;
+  hardware.bluetooth.enable = true;
+
+  # Enable the Cinnamon Desktop Environment.
+  services.xserver.displayManager.lightdm.enable = true;
+  services.xserver.desktopManager.cinnamon.enable = true;
+
+  # Enable Printing
+  services.printing.enable = true;
+  services.avahi = {
+    enable = true;
+    nssmdns4 = true;
+    openFirewall = true;
+  };
+
+  environment.systemPackages = with pkgs; [
+    git
+    firefox
+    libnotify
+    gawk
+    sudo
+    gnome-calculator
+    gnome-calendar
+    gnome-screenshot
+    system-config-printer
+  ];
+}

--- a/installed.nix
+++ b/installed.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  nixpkgs.config.allowUnfree = true;
+  # Fix for the pesky "insecure" broadcom
+  nixpkgs.config.allowInsecurePredicate =
+    pkg:
+    builtins.elem (lib.getName pkg) [
+      "broadcom-sta" # aka “wl”
+    ];
+}


### PR DESCRIPTION
- Adds support for Chromebook audio in `chromebook.nix` (you can remove this if you want, but imo it slights improves hardware support in case Nixbook is installed on Chromebooks and doesn't have a big drawback)
- Puts common config into `common.nix`, which is imported by the installer
- Puts common config not included in the live session in `installed.nix`
- `base.nix` and `base_lite.nix` are also referenced by the installer for the bundled ISO

Supports https://github.com/mkellyxp/nixbook-installer/pull/11