### PR TITLE
Support running appimage as normal

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -23,6 +23,11 @@
     openFirewall = true;
   };
 
+  programs.appimage = {
+    enable = true;
+    binfmt = true;
+  };
+
   # For Chris at LUP :)
   nix.settings.experimental-features = [
     "nix-command"


### PR DESCRIPTION
Enable and register AppImage files as a binary type to binfmt_misc, this let user run appimage just like they would on a normal distro.