### PR TITLE
Make Cinnamon DE overridable by mkDefault

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -12,8 +12,8 @@
   hardware.bluetooth.enable = true;
 
   # Enable the Cinnamon Desktop Environment.
-  services.xserver.displayManager.lightdm.enable = true;
-  services.xserver.desktopManager.cinnamon.enable = true;
+  services.xserver.displayManager.lightdm.enable = lib.mkDefault true;
+  services.xserver.desktopManager.cinnamon.enable = lib.mkDefault true;
 
   # Enable Printing
   services.printing.enable = true;


### PR DESCRIPTION
This will enable users to specify a different Desktop Environment (such as Plasma, xfce, etc) by adding their own configuration changes.