### PR TITLE
feat: add a plymouth boot splash screen and reduce errors logged at startup

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -50,18 +50,6 @@
     "flakes"
   ];
 
-  # VM guest additions to improve host-guest interaction
-  services.spice-vdagentd.enable = true;
-  services.qemuGuest.enable = true;
-  virtualisation.vmware.guest.enable = pkgs.stdenv.hostPlatform.isx86;
-  # https://github.com/torvalds/linux/blob/00b827f0cffa50abb6773ad4c34f4cd909dae1c8/drivers/hv/Kconfig#L7-L8
-  virtualisation.hypervGuest.enable =
-    pkgs.stdenv.hostPlatform.isx86 || pkgs.stdenv.hostPlatform.isAarch64;
-  services.xe-guest-utilities.enable = pkgs.stdenv.hostPlatform.isx86;
-  # The VirtualBox guest additions rely on an out-of-tree kernel module
-  # which lags behind kernel releases, potentially causing broken builds.
-  virtualisation.virtualbox.guest.enable = false;
-
   # Common Packages
   environment.systemPackages = with pkgs; [
     git

--- a/dev.nix
+++ b/dev.nix
@@ -7,6 +7,19 @@
     xclip
     nixfmt
   ];
+
+  # VM guest additions to improve host-guest interaction
+  services.spice-vdagentd.enable = true;
+  services.qemuGuest.enable = true;
+  virtualisation.vmware.guest.enable = pkgs.stdenv.hostPlatform.isx86;
+  # https://github.com/torvalds/linux/blob/00b827f0cffa50abb6773ad4c34f4cd909dae1c8/drivers/hv/Kconfig#L7-L8
+  virtualisation.hypervGuest.enable =
+    pkgs.stdenv.hostPlatform.isx86 || pkgs.stdenv.hostPlatform.isAarch64;
+  services.xe-guest-utilities.enable = pkgs.stdenv.hostPlatform.isx86;
+  # The VirtualBox guest additions rely on an out-of-tree kernel module
+  # which lags behind kernel releases, potentially causing broken builds.
+  virtualisation.virtualbox.guest.enable = false;
+
 }
 
 # To configure helix to use the nix formatter, put this in languages.toml


### PR DESCRIPTION
This PR is my attempt to resolve my issue #73.  I have 2 Nixbook setups one which is using the Grub boot-loader and a 2nd which I setup more recently which has the systemd boot-loader.  This setup works for both and the `boot.loader.grub.gfxpayloadBios = "keep";` is ignored with systemd.

The 2nd change I made is moving the VM guest tools to the `dev.nix` file.  The Hyper-V guest features were causing errors on boot which I was struggling to hide.
```
modprobe: ERROR: could not insert 'hv_balloon' : No such device
modprobe: ERROR: could not insert 'hv_netvsc' : No such device
modprobe: ERROR: could not insert 'hv_storvsc' : No such device
modprobe: ERROR: could not insert 'hv_utils' : No such device
modprobe: ERROR: could not insert 'hv_vmbus' : No such device
```
Since this project was targeting refurbishing hardware, I was thinking moving the VM features to `dev.nix` might be desired.  I expect those options would mostly be used by developers and users experimenting with Nixbook.  Those users are likely able to understand how to include the `dev.nix` in their `configuration.nix` to get those features back.

I feel that moving the VM features is outside of the scope of adding the Plymouth splash screen, but also partially in scope when considering trying to clean up the boot messages.  I understand if these changes are not desired and have no problem reverting them.