### PR TITLE
feat: auto-generate all XDG user dirs in powerwash

### DIFF
--- a/powerwash.sh
+++ b/powerwash.sh
@@ -8,10 +8,7 @@ echo "Powerwashing NixBook..."
   
   # Erase data and set up home directory again
   rm -rf ~/
-  mkdir ~/Desktop
-  mkdir ~/Documents
-  mkdir ~/Downloads
-  mkdir ~/Pictures
+  nix-shell -p xdg-user-dirs --run "xdg-user-dirs-update"
   mkdir ~/.local
   mkdir ~/.local/share
   cp -R /etc/nixbook/config/config ~/.config

--- a/powerwash_lite.sh
+++ b/powerwash_lite.sh
@@ -9,10 +9,7 @@ echo "Powerwashing NixBook Lite..."
   
   # Erase data and set up home directory again
   rm -rf ~/
-  mkdir ~/Desktop
-  mkdir ~/Documents
-  mkdir ~/Downloads
-  mkdir ~/Pictures
+  nix-shell -p xdg-user-dirs --run "xdg-user-dirs-update"
   mkdir ~/.local
   mkdir ~/.local/share
   cp -R /etc/nixbook/config/config_lite ~/.config


### PR DESCRIPTION
rather than doing this manually, just use the command.
im doing `nix-shell -p` since i don't know whether this command is pre-installed on nixbook...